### PR TITLE
Make output bit-for-bit reproducible

### DIFF
--- a/pyx/graph/graph.py
+++ b/pyx/graph/graph.py
@@ -526,7 +526,7 @@ class graphxy(graph):
             # it is an x-axis
             t = trafo.translate_pt(0, self.ypos_pt + v*self.height_pt - axis.positioner.y1_pt)
         c = canvas.canvas()
-        for layer, subcanvas in list(axis.canvas.layers.items()):
+        for layer, subcanvas in sorted(axis.canvas.layers.items()):
             c.layer(layer).insert(subcanvas, [t])
         assert len(axis.canvas.layers) == len(axis.canvas.items), str(axis.canvas.items)
         axis.canvas = c
@@ -579,8 +579,8 @@ class graphxy(graph):
             return
         self.dolayout()
         self.dobackground()
-        for axis in list(self.axes.values()):
-            for layer, canvas in list(axis.canvas.layers.items()):
+        for k, axis in sorted(self.axes.items()):
+            for layer, canvas in sorted(axis.canvas.layers.items()):
                 self.layer("axes.%s" % layer).insert(canvas)
             assert len(axis.canvas.layers) == len(axis.canvas.items), str(axis.canvas.items)
 

--- a/pyx/pdfwriter.py
+++ b/pyx/pdfwriter.py
@@ -105,11 +105,11 @@ class PDFregistry:
 
     def writeresources(self, file):
         file.write("<<\n")
-        file.write("/ProcSet [ %s ]\n" % " ".join(["/%s" % p for p in list(self.procsets.keys())]))
+        file.write("/ProcSet [ %s ]\n" % " ".join(["/%s" % p for p in sorted(self.procsets.keys())]))
         if self.resources:
-            for resourcetype, resources in list(self.resources.items()):
+            for resourcetype, resources in sorted(self.resources.items()):
                 file.write("/%s <<\n%s\n>>\n" % (resourcetype, "\n".join(["/%s %i 0 R" % (name, self.getrefno(object))
-                                                                          for name, object in list(resources.items())])))
+                                                                          for name, object in sorted(resources.items())])))
         file.write(">>\n")
 
 

--- a/pyx/pswriter.py
+++ b/pyx/pswriter.py
@@ -20,7 +20,7 @@
 # along with PyX; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
-import io, copy, time, math
+import io, copy, time, math, os
 from . import bbox, config, style, version, unit, trafo, writer
 
 
@@ -121,11 +121,15 @@ class _PSwriter:
         self.encodings = {}
 
     def writeinfo(self, file):
+        if os.environ.get('SOURCE_DATE_EPOCH'):
+            creation_date = time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH')))
+        else:
+            creation_date = time.localtime()
         file.write("%%%%Creator: PyX %s\n" % version.version)
         if self.title is not None:
             file.write("%%%%Title: %s\n" % self.title)
         file.write("%%%%CreationDate: %s\n" %
-                   time.asctime(time.localtime(time.time())))
+                   time.asctime(creation_date))
 
     def getfontmap(self):
         if self._fontmap is None:


### PR DESCRIPTION
The [Reproducible Builds](https://reproducible-builds.org/) project is working to make compilation outputs from projects bit-for-bit identical so that two users compiling the same source code with the same tools would get the same output. For many packages, there are some nice security benefits in that property; it's also quite compatible with reproducible research, by helping make the path from experiment to publication easily verifiable and bit-for-bit reproducible.

When building PyX, raster and vector graphics generated by PyX are included in the sphinx documentation. Obtaining reproducible sphinx documentation for PyX would mean that (much of?) the output of PyX is indeed reproducible; the sphinx and gcc developers have helped ensure that those tools output is reproducible already.

Alexis Bienvenüe contributed two of these patches to help. We have [tested these patches in the Debian packages for PyX](https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/pyx3.html) and they solve all known randomness in the output of PyX, making it robust to a [wide range of possible variations](https://tests.reproducible-builds.org/debian/index_variations.html). It would be great for them to be upstreamed for the benefit of all.