### PR TITLE
mark files with invalid escape sequences as raw

### DIFF
--- a/pyx/font/t1file.py
+++ b/pyx/font/t1file.py
@@ -639,8 +639,8 @@ class T1File:
     eexecr = 55665
     charstringr = 4330
 
-    fontnamepattern = re.compile("/FontName\s+/(.*?)\s+def\s+")
-    fontmatrixpattern = re.compile("/FontMatrix\s*\[\s*(-?[0-9.]+)\s+(-?[0-9.]+)\s+(-?[0-9.]+)\s+(-?[0-9.]+)\s+(-?[0-9.]+)\s+(-?[0-9.]+)\s*\]\s*(readonly\s+)?def")
+    fontnamepattern = re.compile(r"/FontName\s+/(.*?)\s+def\s+")
+    fontmatrixpattern = re.compile(r"/FontMatrix\s*\[\s*(-?[0-9.]+)\s+(-?[0-9.]+)\s+(-?[0-9.]+)\s+(-?[0-9.]+)\s+(-?[0-9.]+)\s+(-?[0-9.]+)\s*\]\s*(readonly\s+)?def")
 
     def __init__(self, data1, data2eexec, data3):
         """initializes a t1font instance
@@ -706,7 +706,7 @@ class T1File:
                     break
                 assert token == "dup"
 
-    lenIVpattern = re.compile(b"/lenIV\s+(\d+)\s+def\s+")
+    lenIVpattern = re.compile(rb"/lenIV\s+(\d+)\s+def\s+")
     flexhintsubrs = [[3, 0, T1callothersubr, T1pop, T1pop, T1setcurrentpoint, T1return],
                      [0, 1, T1callothersubr, T1return],
                      [0, 2, T1callothersubr, T1return],
@@ -997,9 +997,9 @@ class T1File:
         # note that self._data2 is out-of-date here too, hence we need to call getdata2
         return self._eexecencode(self.getdata2())
 
-    newlinepattern = re.compile("\s*[\r\n]\s*")
-    uniqueidstrpattern = re.compile("%?/UniqueID\s+\d+\s+def\s+")
-    uniqueidbytespattern = re.compile(b"%?/UniqueID\s+\d+\s+def\s+")
+    newlinepattern = re.compile("\\s*[\r\n]\\s*")
+    uniqueidstrpattern = re.compile(r"%?/UniqueID\s+\d+\s+def\s+")
+    uniqueidbytespattern = re.compile(rb"%?/UniqueID\s+\d+\s+def\s+")
         # when UniqueID is commented out (as in modern latin), prepare to remove the comment character as well
 
     def getstrippedfont(self, glyphs, charcodes):
@@ -1092,11 +1092,11 @@ class T1File:
         data1 = self.data1
         data3 = self.data3
         if remove_UniqueID_lookup:
-            m1 = re.search("""FontDirectory\s*/%(name)s\s+known{/%(name)s\s+findfont\s+dup\s*/UniqueID\s+known\s*{\s*dup\s*
+            m1 = re.search(r"""FontDirectory\s*/%(name)s\s+known{/%(name)s\s+findfont\s+dup\s*/UniqueID\s+known\s*{\s*dup\s*
                               /UniqueID\s+get\s+\d+\s+eq\s+exch\s*/FontType\s+get\s+1\s+eq\s+and\s*}\s*{\s*pop\s+false\s*}\s*ifelse\s*
                               {save\s+true\s*}\s*{\s*false\s*}\s*ifelse\s*}\s*{\s*false\s*}\s*ifelse""" % {"name": self.name},
                            data1, re.VERBOSE)
-            m3 = re.search("\s*{restore}\s*if", data3)
+            m3 = re.search(r"\s*{restore}\s*if", data3)
             if m1 and m3:
                 data1 = data1[:m1.start()] + data1[m1.end():]
                 data3 = data3[:m3.start()] + data3[m3.end():]

--- a/pyx/graph/axis/texter.py
+++ b/pyx/graph/axis/texter.py
@@ -42,7 +42,7 @@ class _texter:
 
 
 class decimal(_texter):
-    "a texter creating decimal labels (e.g. '1.234' or even '0.\overline{3}')"
+    r"a texter creating decimal labels (e.g. '1.234' or even '0.\overline{3}')"
 
     def __init__(self, prefix="", infix="", suffix="", equalprecision=False,
                        decimalsep=".", thousandsep="", thousandthpartsep="",
@@ -145,7 +145,7 @@ skipmantissaunity.all = 2
 
 class default(_texter):
 
-    "a texter creating regular (e.g. '2') and exponential (e.g. '2\cdot10^5') labels"
+    r"a texter creating regular (e.g. '2') and exponential (e.g. '2\cdot10^5') labels"
 
     def __init__(self, multiplication_tex=r"\cdot{}", multiplication_unicode="·", base=Fraction(10),
                        skipmantissaunity=skipmantissaunity.all, minusunity="-",
@@ -261,7 +261,7 @@ class default(_texter):
 
 
 class rational(_texter):
-    "a texter creating rational labels (e.g. 'a/b' or even 'a \over b')"
+    r"a texter creating rational labels (e.g. 'a/b' or even 'a \over b')"
     # we use divmod here to be more explicit
 
     def __init__(self, prefix="", infix="", suffix="",

--- a/pyx/mathutils.py
+++ b/pyx/mathutils.py
@@ -109,7 +109,7 @@ def _realroots_quartic(a3, a2, a1, a0):
 
 
 def realpolyroots(*cs):
-    """returns the roots of a polynom with given coefficients
+    r"""returns the roots of a polynom with given coefficients
 
     polynomial with coefficients given in cs:
       0 = \sum_i  cs[i] * x^(len(cs)-i-1)

--- a/pyx/svgfile.py
+++ b/pyx/svgfile.py
@@ -83,11 +83,11 @@ class svgValueError(ValueError): pass
 
 class _marker: pass
 
-_svgFloatPattern = re.compile("(?P<value>[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)(?P<unit>(px|pt|pc|mm|cm|in|%)?)\s*,?\s*")
-_svgBoolPattern = re.compile("(?P<bool>[01])\s*,?\s*")
-_svgPathPattern = re.compile("(?P<cmd>[mlhvcsqtaz])\s*(?P<args>(([^mlhvcsqtaz]|pt|pc|mm|cm)*))", re.IGNORECASE)
-_svgColorAbsPattern = re.compile("rgb\(\s*(?P<red>[0-9]+)\s*,\s*(?P<green>[0-9]+)\s*,\s*(?P<blue>[0-9]+)\s*\)$", re.IGNORECASE)
-_svgColorRelPattern = re.compile("rgb\(\s*(?P<red>[0-9]+)%\s*,\s*(?P<green>[0-9]+)%\s*,\s*(?P<blue>[0-9]+)%\s*\)$", re.IGNORECASE)
+_svgFloatPattern = re.compile(r"(?P<value>[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)(?P<unit>(px|pt|pc|mm|cm|in|%)?)\s*,?\s*")
+_svgBoolPattern = re.compile(r"(?P<bool>[01])\s*,?\s*")
+_svgPathPattern = re.compile(r"(?P<cmd>[mlhvcsqtaz])\s*(?P<args>(([^mlhvcsqtaz]|pt|pc|mm|cm)*))", re.IGNORECASE)
+_svgColorAbsPattern = re.compile(r"rgb\(\s*(?P<red>[0-9]+)\s*,\s*(?P<green>[0-9]+)\s*,\s*(?P<blue>[0-9]+)\s*\)$", re.IGNORECASE)
+_svgColorRelPattern = re.compile(r"rgb\(\s*(?P<red>[0-9]+)%\s*,\s*(?P<green>[0-9]+)%\s*,\s*(?P<blue>[0-9]+)%\s*\)$", re.IGNORECASE)
 
 
 class svgBaseHandler(xml.sax.ContentHandler):
@@ -242,7 +242,7 @@ class svgHandler(svgBaseHandler):
 
     def toTrafo(self, svgTrafo):
         t = trafo.identity
-        for match in reversed(list(re.finditer("(?P<cmd>matrix|translate|scale|rotate|skewX|skewY)\((?P<args>[^)]*)\)", svgTrafo))):
+        for match in reversed(list(re.finditer(r"(?P<cmd>matrix|translate|scale|rotate|skewX|skewY)\((?P<args>[^)]*)\)", svgTrafo))):
             cmd = match.group("cmd")
             args = match.group("args")
             if cmd == "matrix":


### PR DESCRIPTION
This PR addresses the comment https://sourceforge.net/p/pyx/mailman/message/36732745/ on the pyx-user mailing list by marking strings with invalid escape sequences as raw. In one case, `\s` was replaced by `\\s` because the string contained also the valid escape sequences `\r` and `\w`.