### PR TITLE
replace distutils by setuptools to avoid warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ old releases up to PyX 0.12.x, i.e. execute something like:
     exit()
 
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import configparser
 import pyx.version
 


### PR DESCRIPTION
`distutils.core` issues a `UserWarning` complaining about the `python_requires` and `extras_require` keywords (cf. https://sourceforge.net/p/pyx/mailman/message/36733909/). It seems that this should be solved by switching to `setuptools` which is proposed in this PR. It should be checked though whether this is indeed the right thing to do.