### PR TITLE
[DOC] two corrections in description

### DIFF
--- a/examples/text/unicodeengine.txt
+++ b/examples/text/unicodeengine.txt
@@ -1,8 +1,8 @@
 Unicode engine
 
 PyX supports basic text output without using TeX/LaTeX by
-by `text.UnicodeEngine` instances.... The font defaults to
-Computer Modern at 10 pt. It can be set by paramters of the
+`text.UnicodeEngine` instances.... The font defaults to
+Computer Modern at 10 pt. It can be set by parameters of the
 constructor and for the default engine via the set command:
 
     text.set(text.UnicodeEngine, fontname="cmss10", size=14)


### PR DESCRIPTION
This PR corrects two small mistakes in the description of the example for the Unicode engine.