### PR TITLE
fixes in TeX/LaTeX-FAQ

### DIFF
--- a/faq/tex_latex.rst
+++ b/faq/tex_latex.rst
@@ -95,11 +95,12 @@ Undefined control sequence ``\usepackage``
 ------------------------------------------
 
 The command ``\usepackage`` is specific to LaTeX. Since by default PyX
-uses TeX, you have to specify the correct mode::
+uses TeX, you have to specify the correct typesetting engine::
 
-   text.set(mode="latex")
+   text.set(text.LatexEngine)
 
 Undefined control sequence ``\frac``
+------------------------------------
 
 The command ``\frac`` is only available in LaTeX. The equivalent to
 ``\frac{a}{b}`` in TeX is ``{a \over b}``.  As an alternative you may ask for

--- a/faq/tex_latex.rst
+++ b/faq/tex_latex.rst
@@ -104,7 +104,7 @@ Undefined control sequence ``\frac``
 
 The command ``\frac`` is only available in LaTeX. The equivalent to
 ``\frac{a}{b}`` in TeX is ``{a \over b}``.  As an alternative you may ask for
-the LaTeX mode as explained in :ref:`undefined_usepackage`.
+the LaTeX engine as explained in :ref:`undefined_usepackage`.
 
 Missing ``$`` inserted
 ----------------------
@@ -140,7 +140,7 @@ not allow linebreaks to occur. There are two ways out.
 If the text material should go in a box of given width, a parbox can be used
 like in the following example::
 
-   text.set(mode="latex")
+   text.set(text.LatexEngine)
    c = canvas.canvas()
    w = 2
    c.text(0, 0, r"\begin{itemize}\item a\item b\end{itemize}", [text.parbox(w)])
@@ -151,7 +151,7 @@ is useful which provides several environments like ``Bitemize`` and
 ``Beqnarray`` which can be processed in LR mode. The relevant part of the code
 could look like::
 
-   text.set(mode="latex")
+   text.set(text.LatexEngine)
    text.preamble(r"\usepackage{fancybox}")
    c = canvas.canvas()
    c.text(0, 0, r"\begin{Bitemize}\item a\item b\end{Bitemize}")
@@ -277,7 +277,7 @@ problem (even though it may cost you some time to set up things properly).
 In the simplest case, your LaTeX system contains everything needed. 
 Including the following line into your code will probably work::
 
-    text.set(mode="latex")
+    text.set(text.LatexEngine)
     text.preamble(r"\usepackage{mathptmx}")
 
 and give you Times as roman font. 


### PR DESCRIPTION
In view of an upcoming FAQ entry on the ``UnicodeEngine`` (cf. #11), this PR fixes a couple of points in the section on TeX and LaTeX. In one place, the markup for a question was missing and a couple of usages of the deprecated ``mode`` keyword have been updated.