### PR TITLE
Change to import setup and Extension from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ old releases up to PyX 0.12.x, i.e. execute something like:
     exit()
 
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import configparser
 import pyx.version
 


### PR DESCRIPTION
Change to import setup and Extension from setuptools in order to
support --single-version-externally-managed, which is needed for
the OpenBSD ports infrastructure.