### PR TITLE
Unrecognized floating point number when parsing afm fonts(DejaVuSans.afm)

### DIFF
--- a/pyx/font/afmfile.py
+++ b/pyx/font/afmfile.py
@@ -896,6 +896,8 @@ def _parsehex(s):
         raise AFMError("Expecting hexadecimal int, got '%s'" % s)
 
 def _parsefloat(s):
+    if ',' in s:
+        s = s.replace(',', '.', 1)
     try:
         return float(s)
     except:


### PR DESCRIPTION
```
UnderlinePosition -41,5039
UnderlineThickness 43,9453
```
According to https://adobe-type-tools.github.io/font-tech-notes/pdfs/5004.AFM_Spec.pdf (page 10&14). We expect this should be an integer or floating point number, but here it contains a comma.