### PR TITLE
fix t1 extension with Python 3.10

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-0.xx (2020/xx/xx):
+0.xx (2021/xx/xx):
   - graph.axis.style:
     - Allow invalid values (e.g. None) in color values of density style.
   - text module:
@@ -9,6 +9,8 @@
     - fix bitmap palette data pdf output being bytes
   - canvas module:
      - add clear() method to canvas class (suggested by Camilo Talero)
+  - t1 extension module:
+     - adjust to int/Py_ssize_t change in python 3.10 (thanks to Michael J Gruber)
 
 0.15 (2019/07/14):
   - text module:

--- a/pyx/font/_t1code.c
+++ b/pyx/font/_t1code.c
@@ -10,6 +10,8 @@
  *  USA.
  */
 
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -32,11 +34,12 @@ def decoder(code, r, n):
 static PyObject *py_decoder(PyObject *self, PyObject *args)
 {
     unsigned char *code;
-    int lcode, pr, n;
+    Py_ssize_t lcode;
+    int pr, n;
 
     if (PyArg_ParseTuple(args, "y#ii", (char **) &code, &lcode, &pr, &n)) {
       unsigned char *data;
-      int i;
+      Py_ssize_t i;
       unsigned char x;
       uint16_t r=pr;
       PyObject *result;
@@ -74,11 +77,12 @@ static PyObject *py_encoder(PyObject *self, PyObject *args)
 {
     unsigned char *data;
     unsigned char *random;
-    int ldata, pr, lrandom;
+    Py_ssize_t ldata, lrandom;
+    int pr;
 
     if (PyArg_ParseTuple(args, "y#iy#", (char **) &data, &ldata, &pr, (char **) &random, &lrandom)) {
       unsigned char *code;
-      int i;
+      Py_ssize_t i;
       uint16_t r=pr;
       PyObject *result;
 


### PR DESCRIPTION
For all # variants of formats (s#, y#, etc.), the macro PY_SSIZE_T_CLEAN
must be defined before including Python.h. On Python 3.9 and older, the
type of the length argument is Py_ssize_t if the PY_SSIZE_T_CLEAN macro
is defined, or int otherwise. [https://docs.python.org/3.10/c-api/arg.html]

So, on Python 3.9, PyX worked because PY_SSIZE_T_CLEAN was not defined
(even though it was recommended), so that the deprecated return type of
int was used.

Python 3.10 finally pulls the trigger on the ints, so finally adjust to
that announced change.