### PR TITLE
meaning of parameter a in slant clarified

### DIFF
--- a/manual/trafo.rst
+++ b/manual/trafo.rst
@@ -68,7 +68,8 @@ be obtained via the ``trafo`` method ``inverse()``, defined by the inverse
 
 .. method:: slanted(a, angle=0, x=None, y=None)
 
-   returns ``trafo`` followed by slant by ``angle`` around point
+   returns ``trafo`` followed by slant by factor ``a`` in the direction
+   given by ``angle`` around point
    :math:`(\mathtt{x}, \mathtt{y})`, or :math:`(0,0)`, if not given.
 
 .. method:: translated(x, y)
@@ -99,7 +100,8 @@ each of which corresponds to one ``trafo`` method.
 
 .. class:: slant(a, angle=0, x=None, y=None)
 
-   slant by ``angle`` around point :math:`(\mathtt{x}, \mathtt{y})`, or :math:`(0,0)`, if not given.
+   slant by factor ``a`` in the direction given by ``angle`` around point :math:`(\mathtt{x}, \mathtt{y})`,
+   or :math:`(0,0)`, if not given.
 
 .. class:: translate(x, y)
 


### PR DESCRIPTION
The documentation of the ``trafo.slant`` method does not mention its most important parameter ``a``. The present text might actually mislead the reader into thinking that the amplitude of the slant is characterized by ``angle``. This PR proposes a way to mention the parameter ``a``.