### PR TITLE
Add illustration for arct()

### DIFF
--- a/manual/arct.py
+++ b/manual/arct.py
@@ -1,0 +1,16 @@
+#!/bin/python3
+from pyx import *
+c = canvas.canvas()
+def bluedot(x, y):
+    c.fill(path.circle_pt(x, y, 2), [color.rgb.blue])
+c.stroke(path.path(path.moveto(0, 0), path.arct(2, 0, 1.5, 1, 0.5)))
+def bluedot(x, y):
+    c.fill(path.circle(x, y, 0.03), [color.rgb.blue])
+bluedot(0, 0)
+bluedot(2, 0)
+bluedot(1.5, 1)
+margin=0.1
+c.text(0-margin, 0, r"current point $(0, 0)$", [text.halign.right, text.valign.baseline])
+c.text(2+margin, 0, r"$(2, 0)$", [text.halign.left, text.valign.baseline])
+c.text(1.5-margin, 1, r"$(1.5, 1)$", [text.halign.right, text.valign.baseline])
+c.writePDFfile()

--- a/manual/path.rst
+++ b/manual/path.rst
@@ -243,6 +243,15 @@ available:
    through the current point and *x1*, *y1*. The arc then continues to the
    point where the circle touches the line through *x1*, *y1* and *x2*, *y2*.
 
+   For example, the following code::
+
+      c.stroke(path.path(path.moveto(0, 0), path.arct(2, 0, 1.5, 1, 0.5)))
+
+   will result in the following figure.
+
+   .. figure:: arct.*
+      :align:  center
+
 Bézier curves can be constructed using:
 
 .. class:: curveto(x1, y1, x2, y2, x3, y3)


### PR DESCRIPTION
Rationale: I find the original description exceedingly difficult to understand.

Result looks like this.

![image](https://github.com/pyx-project/pyx/assets/25191436/20d8a5e0-181b-460d-9441-cb1c16278b79)
